### PR TITLE
feat(evidence): 이미지 도메인 추가

### DIFF
--- a/src/main/java/com/capstone/dfbf/api/evidence/domain/Comparison.java
+++ b/src/main/java/com/capstone/dfbf/api/evidence/domain/Comparison.java
@@ -1,0 +1,30 @@
+package com.capstone.dfbf.api.evidence.domain;
+
+import com.capstone.dfbf.global.base.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comparison extends BaseEntity implements Evidence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imgUrl;
+
+    @Override
+    public Evidence updateImgUrl(String imgUrl) {
+        return Comparison.builder()
+                .id(this.id)
+                .imgUrl(imgUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/dfbf/api/evidence/domain/Evidence.java
+++ b/src/main/java/com/capstone/dfbf/api/evidence/domain/Evidence.java
@@ -1,0 +1,6 @@
+package com.capstone.dfbf.api.evidence.domain;
+
+public interface Evidence {
+
+    public Evidence updateImgUrl(String imgUrl);
+}

--- a/src/main/java/com/capstone/dfbf/api/evidence/domain/EvidenceGroup.java
+++ b/src/main/java/com/capstone/dfbf/api/evidence/domain/EvidenceGroup.java
@@ -1,0 +1,23 @@
+package com.capstone.dfbf.api.evidence.domain;
+
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Entity
+public class EvidenceGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Verification verification;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Comparison> comparisons;
+
+    public void addComparison(Comparison comparison) {
+        comparisons.add(comparison);
+    }
+}

--- a/src/main/java/com/capstone/dfbf/api/evidence/domain/Verification.java
+++ b/src/main/java/com/capstone/dfbf/api/evidence/domain/Verification.java
@@ -1,0 +1,30 @@
+package com.capstone.dfbf.api.evidence.domain;
+
+import com.capstone.dfbf.global.base.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Verification extends BaseEntity implements Evidence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imgUrl;
+
+    @Override
+    public Evidence updateImgUrl(String imgUrl) {
+        return Comparison.builder()
+                .id(this.id)
+                .imgUrl(imgUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/dfbf/api/result/domain/AnalysisResult.java
+++ b/src/main/java/com/capstone/dfbf/api/result/domain/AnalysisResult.java
@@ -26,6 +26,9 @@ public class AnalysisResult extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    private AnalysisResult analysisResult;
+
     public AnalysisResult updateWith(final AppraisalResponse response) {
         return AnalysisResult.builder()
                 .id(this.id)


### PR DESCRIPTION
도메인 추가해 봤습니다!

기존에 논의됐던 추상클래스는 제거하고 검증물과 대조물에 필드를 각각 넣어주었습니다.

`EvidenceGroup`은 그대로 사용하여 `Analysis`와 `OnetoOne`을 가지도록 구성했습니다.

모든 객체 간의 연관 관계는 `단방향 매핑`으로 구현했습니다. 현재 하위 도메인(Verification, Comparison)에서 역으로 EvidenceGroup을 사용하는 메서드가 설계 시에 정의되어 있지 않아 불필요한 양방향 매핑을 제거했습니다.

추후 양방향 매핑 필요 시, 추가하면 좋을 것 같습니다!