### PR TITLE
[feat] 회원가입, 이메일 중복 api 설계

### DIFF
--- a/src/main/java/com/capstone/dfbf/api/member/Member.java
+++ b/src/main/java/com/capstone/dfbf/api/member/Member.java
@@ -28,7 +28,7 @@ public class Member extends BaseEntity {
 //        private String type;
 //    }
 
-    public static Member createMember(String email, String encodedPassword){
+    public static Member create(String email, String encodedPassword){
         return Member.builder()
                 .email(email)
                 .encodedPassword(encodedPassword)

--- a/src/main/java/com/capstone/dfbf/api/member/controller/MemberController.java
+++ b/src/main/java/com/capstone/dfbf/api/member/controller/MemberController.java
@@ -1,14 +1,13 @@
 package com.capstone.dfbf.api.member.controller;
 
 import com.capstone.dfbf.api.member.dto.LoginReqDto;
+import com.capstone.dfbf.api.member.dto.SignUpReqDto;
 import com.capstone.dfbf.api.member.service.MemberService;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,7 +18,17 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/login")
-    public void login(@RequestBody LoginReqDto reqDto, HttpServletResponse response) {
+    public void login(@Valid @RequestBody LoginReqDto reqDto, HttpServletResponse response) {
         memberService.login(reqDto, response);
+    }
+
+    @GetMapping("/check-email")
+    public void checkEmail(@RequestParam String email) {
+        memberService.validateEmail(email);
+    }
+
+    @PostMapping("/signup")
+    public void signup(@Valid @RequestBody SignUpReqDto request){
+        memberService.signup(request);
     }
 }

--- a/src/main/java/com/capstone/dfbf/api/member/dto/SignUpReqDto.java
+++ b/src/main/java/com/capstone/dfbf/api/member/dto/SignUpReqDto.java
@@ -1,0 +1,19 @@
+package com.capstone.dfbf.api.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class SignUpReqDto {
+    @Email(message = "이메일 형식으로 작성해주세요")
+    private String email;
+
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[!@#$%^&*(),.?\":{}|<>]).{10,}$",
+            message = "비밀번호는 10자 이상이며 특수문자를 하나 이상 포함해야 합니다."
+    )
+    private String password;
+}

--- a/src/main/java/com/capstone/dfbf/api/member/error/MemberError.java
+++ b/src/main/java/com/capstone/dfbf/api/member/error/MemberError.java
@@ -12,6 +12,7 @@ public enum MemberError implements BaseCode {
 
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "M000", "비밀번호가 올바르지 않습니다.", ErrorDisplayType.POPUP),
     NON_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "M001", "존재하지 않은 회원입니다.", ErrorDisplayType.POPUP),
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "M002", "존재하는 이메일입니다.", ErrorDisplayType.POPUP),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/capstone/dfbf/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/capstone/dfbf/api/member/repository/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/capstone/dfbf/api/member/service/MemberService.java
+++ b/src/main/java/com/capstone/dfbf/api/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.capstone.dfbf.api.member.service;
 
 import com.capstone.dfbf.api.member.Member;
 import com.capstone.dfbf.api.member.dto.LoginReqDto;
+import com.capstone.dfbf.api.member.dto.SignUpReqDto;
 import com.capstone.dfbf.api.member.error.MemberError;
 import com.capstone.dfbf.api.member.error.MemberException;
 import com.capstone.dfbf.api.member.repository.MemberRepository;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -22,25 +24,41 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
-    public void login(LoginReqDto request, HttpServletResponse response){
-        Member member = loadMemberOrRegister(request);
+    @Transactional(readOnly = true)
+    public void login(LoginReqDto request, HttpServletResponse response) {
+        Member member = loadMemberOrThrow(request);
+        validatePassword(request, member);
         AccessTokenVO accessToken = jwtProvider.generateAccessToken(member);
         response.setHeader("Authorization", "Bearer " + accessToken.token());
     }
 
-    private Member loadMemberOrRegister(LoginReqDto request){
+    @Transactional
+    public void signup(SignUpReqDto request) {
+        validateMemberExistByEmail(request.getEmail());
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        Member member = Member.create(request.getEmail(), encodedPassword);
+        memberRepository.save(member);
+    }
+
+    @Transactional(readOnly = true)
+    public void validateEmail(String email){
+        validateMemberExistByEmail(email);
+    }
+
+    private Member loadMemberOrThrow(LoginReqDto request) {
         return memberRepository.findMemberByEmail(request.getEmail())
-                .map(member -> {
-                    if (!passwordEncoder.matches(request.getPassword(), member.getEncodedPassword())) {
-                        throw new MemberException(MemberError.INVALID_PASSWORD);
-                    }
-                    return member;
-                })
-                .orElseGet(() -> {
-                    String encodedPassword = passwordEncoder.encode(request.getPassword());
-                    Member newMember = Member.createMember(request.getEmail(), encodedPassword);
-                    memberRepository.save(newMember);
-                    return newMember;
-                });
+                .orElseThrow(() -> new MemberException(MemberError.NON_EXIST_MEMBER));
+    }
+
+    private void validatePassword(LoginReqDto request, Member member) {
+        if (!passwordEncoder.matches(request.getPassword(), member.getEncodedPassword())) {
+            throw new MemberException(MemberError.INVALID_PASSWORD);
+        }
+    }
+
+    private void validateMemberExistByEmail(String email) {
+        if(memberRepository.existsByEmail(email)){
+            throw MemberException.from(MemberError.ALREADY_EXIST_EMAIL);
+        }
     }
 }

--- a/src/main/java/com/capstone/dfbf/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/dfbf/global/exception/handler/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.capstone.dfbf.global.exception.handler;
 
 import com.capstone.dfbf.global.exception.BaseException;
 import com.capstone.dfbf.global.exception.error.ErrorCode;
-import com.capstone.dfbf.global.exception.error.ErrorDisplayType;
 import com.capstone.dfbf.global.exception.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(annotations = {RestController.class})
 public class GlobalExceptionHandler {
 
-
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> onThrowException(BaseException baseException) {
         ErrorResponse response = ErrorResponse.generateErrorResponse(baseException);
@@ -27,7 +25,7 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.builder()
                 .code(ErrorCode.BINDING_ERROR.getCode())
                 .message(exception.getBindingResult().getFieldError().getDefaultMessage())
-                .displayType(ErrorDisplayType.POPUP)
+                .displayType(ErrorCode.BINDING_ERROR.getDisplayType())
                 .build();
         return ResponseEntity.status(exception.getStatusCode()).body(response);
     }

--- a/src/main/java/com/capstone/dfbf/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/dfbf/global/security/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/", "/index/**", "/index.js", "/favicon.ico", "/.well-known/**",
-                                "/templates", "/error", "/v3/api-docs/**", "/swagger-ui/**", "/api/v1/login", "/actuator/**").permitAll()
+                                "/templates", "/error", "/v3/api-docs/**", "/swagger-ui/**", "/api/v1/login",
+                                "/api/v1/signup",  "/api/v1/check-email","/actuator/**").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling((exceptionHandling) -> exceptionHandling
                         .authenticationEntryPoint(authenticationEntryPoint)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: "optional:application-dev.yml"
+    import: "optional:application-local.yml"
 
 management:
   endpoints:


### PR DESCRIPTION
## #️⃣ 이슈

- #36 


## 🔎 작업 내용

기존 폼 로그인 로직을 수정하고 회원가입, 이메일 중복 api를 설계했다.

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

현재는 로그아웃을 서버가 관리하지 않습니다. 대게 레디스를 활용해 블랙리스트를 관리하는데, 레디스를 현 서비스에 도입하지 않아 프론트에서 Authorization 헤더에 액세스 토큰 값을 제거하는 방법을 채택했습니다.
